### PR TITLE
Expand README with infrastructure hub ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - Einführung von Gemeinwohlbilanzen für Unternehmen.
 - Förderung von Kooperativen, Sharing-Economy, solidarischer Landwirtschaft.
 - Bedingungsloses Grundeinkommen in Modellregionen testen.
+- Solidarische Crowd-Finanzierung innovativer Projekte wie Gesundheits-Start-ups über regionale Fonds.
 
 ---
 
@@ -46,6 +47,8 @@
 - Ethische Leitlinien für KI, Biotechnologie und Automatisierung.
 - Freie Zugänge zu Gesundheitsdaten, Forschung und Open-Source-Software.
 - Aufbau gemeinwohlorientierter digitaler Infrastrukturen.
+- Offene Sensornetzwerke für Klima- und Gesundheitsdaten als Frühwarnsysteme.
+- Modulare Microgrid-Bausteine für kommunale Infrastruktur-Hubs und Gesundheitszentren.
 
 ---
 
@@ -79,6 +82,9 @@
 - Mobile Solarkliniken für schwer erreichbare Regionen.
 - Regenwassermanagement und Energiespeicher an Gesundheitszentren.
 - Kooperative Transportnetzwerke für Medikamente und Material (z.B. per Lastenrad).
+- Bürgerbetriebene Infrastruktur-Hubs für lokale Energie- und Versorgungsnetze.
+- Hybrid-Solar-Wind-Microgrids an Gesundheitsstationen.
+- Regionale Datenplattformen für Klima- und Gesundheitsmonitoring.
 
 ---
 
@@ -98,3 +104,5 @@
 12. Offene Sensornetzwerke für Hitze- und Luftqualitätswarnungen einsetzen und mit Telemedizin verknüpfen.
 13. Kooperationen mit lokalen Bau- und Reparaturinitiativen für resilientere Infrastruktur fördern.
 14. Wiederverwendbare modulare Gebäudeelemente für Notfallkliniken entwickeln.
+15. Finanzierung innovativer Gesundheits-Start-ups über solidarische Crowdmodelle und regionale Fonds.
+16. Partnerschaften zwischen Universitäten und Kommunen für resiliente Bauweisen aufbauen.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,5 +1,3 @@
 Auszuführen im nächsten Schritt:
 
-Baue vorhandene Ideen in README.md weiteraus.
-Nutze auch codex/daten/brain.md
-Wenn du fertig bist, erstelle dir in codex/daten/prompt.md den nächsten Prompt für dich selbst, zum weiterarbeiten im nächsten Schritt.
+Analysiere die Verzahnung von Technologie (Kapitel 5) und Gesundheitsversorgung (Kapitel 8). Entwickle ein kurzes Konzept für bürgerbetriebene Infrastruktur-Hubs und integriere es in das README. Ergänze danach im Abschnitt "Nächste Schritte" weitere Ideen zur solidarischen Finanzierung. Anschließend erstelle einen neuen Arbeitsauftrag in codex/daten/prompt.md.


### PR DESCRIPTION
## Summary
- expand economic chapter with solidarity crowdfunding bullet
- broaden technology chapter with sensor networks and microgrids
- add infrastructure hubs and monitoring lines to health chapter
- extend next steps list with crowdfunding and university partnerships
- set next todo prompt for continuing work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688761967a54832e84b8ef9f2db68632